### PR TITLE
Modifications regarding logging, exception handling, chdir bug

### DIFF
--- a/bayeosgatewayclient/samplescripts/samplethreadWithLogging.py
+++ b/bayeosgatewayclient/samplescripts/samplethreadWithLogging.py
@@ -1,15 +1,16 @@
 """Creates an example writer and sender using threads."""
 from time import sleep
 from bayeosgatewayclient import BayEOSWriter, BayEOSSender
+import logging
 
 PATH = '/tmp/bayeos-device/'
-NAME = 'Python-Thread-Example2'
+NAME = 'Python-Thread-WithLogging'
 URL = 'http://bayconf.bayceer.uni-bayreuth.de/gateway/frame/saveFlat'
 
-writer = BayEOSWriter(PATH)
+writer = BayEOSWriter(PATH,max_time=10,log_level=logging.DEBUG)
 writer.save_msg('Writer was started.')
 
-sender = BayEOSSender(PATH, NAME, URL)
+sender = BayEOSSender(PATH, NAME, URL,backup_path='/dev/shm/bayeos-device')
 sender.start()
 
 while True:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError as ierr:
 
 setup(
     name='bayeosgatewayclient',
-    version='0.2.5',
+    version='0.2.6',
     packages=['bayeosgatewayclient'],
     description='A Python package to transfer client data to a BayEOS Gateway.',
     author='Anja Kleebaum, Stefan Holzheu, Oliver Archner',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError as ierr:
 
 setup(
     name='bayeosgatewayclient',
-    version='0.2.3',
+    version='0.2.4',
     packages=['bayeosgatewayclient'],
     description='A Python package to transfer client data to a BayEOS Gateway.',
     author='Anja Kleebaum, Stefan Holzheu, Oliver Archner',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError as ierr:
 
 setup(
     name='bayeosgatewayclient',
-    version='0.2.4',
+    version='0.2.5',
     packages=['bayeosgatewayclient'],
     description='A Python package to transfer client data to a BayEOS Gateway.',
     author='Anja Kleebaum, Stefan Holzheu, Oliver Archner',


### PR DESCRIPTION
Runing the library we still had the problem, that sometimes the sender thread died unexpectedly. To find out the reason, I added
- more logging (-> changed to logging-class)
- more exception handling

Finally I found a bug related to chdir and backup_path. As the sender runs as thread. The current path is always the same as for the writer. Invoking chdir from sender and writer could mess up things. Thus I removed chdir statements and use absolute path names.
